### PR TITLE
Canny Edge Detection StableDiffusionControlNet and StableDiffusionControlNetImg2Img Pipelines

### DIFF
--- a/examples/react/config-overrides.js
+++ b/examples/react/config-overrides.js
@@ -1,0 +1,12 @@
+module.exports = {
+    // The Webpack config to use when compiling your react app for development or production.
+    webpack: function (config, env) {
+      // set resolve.fallback
+      config.resolve.fallback = {
+        fs: false,
+        path: false,
+        crypto: false,
+      };
+      return config;
+    },
+};

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -8,6 +8,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.14.0",
+    "@techstark/opencv-js": "4.8.0-release.10",
     "@types/jest": "^27.5.2",
     "@types/react": "^18.2.8",
     "@types/react-dom": "^18.2.4",
@@ -22,9 +23,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "yarn setup && react-scripts start",
-    "build": "yarn setup && react-scripts build",
-    "test": "react-scripts test",
+    "start": "yarn setup && react-app-rewired start",
+    "build": "yarn setup && react-app-rewired build",
+    "test": "react-app-rewired test",
     "eject": "react-scripts eject",
     "setup": "node ort-wasm-handler.js"
   },
@@ -48,7 +49,8 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "@types/lodash": "^4.14.195"
+    "@types/lodash": "^4.14.195",
+    "react-app-rewired": "2.2.1"
   },
   "overrides": {
     "@xenova/transformers": {

--- a/src/pipelines/DiffusionPipeline.ts
+++ b/src/pipelines/DiffusionPipeline.ts
@@ -2,6 +2,7 @@ import { PretrainedOptions } from '@/pipelines/common'
 import { GetModelFileOptions } from '@/hub/common'
 import { getModelJSON } from '@/hub'
 import { StableDiffusionPipeline } from '@/pipelines/StableDiffusionPipeline'
+import { StableDiffusionControlNetPipeline } from './StableDiffusionControlNetPipeline'
 import { StableDiffusionXLPipeline } from '@/pipelines/StableDiffusionXLPipeline'
 import { LatentConsistencyModelPipeline } from '@/pipelines/LatentConsistencyModelPipeline'
 
@@ -16,7 +17,12 @@ export class DiffusionPipeline {
     switch (index['_class_name']) {
       case 'StableDiffusionPipeline':
       case 'OnnxStableDiffusionPipeline':
-        return StableDiffusionPipeline.fromPretrained(modelRepoOrPath, options)
+        if (typeof index['controlnet'] === 'undefined') {
+          return StableDiffusionPipeline.fromPretrained(modelRepoOrPath, options)
+        }
+        else {
+          return StableDiffusionControlNetPipeline.fromPretrained(modelRepoOrPath, options) 
+        }
       case 'StableDiffusionXLPipeline':
       case 'ORTStableDiffusionXLPipeline':
         return StableDiffusionXLPipeline.fromPretrained(modelRepoOrPath, options)

--- a/src/pipelines/StableDiffusionControlNetPipeline.ts
+++ b/src/pipelines/StableDiffusionControlNetPipeline.ts
@@ -1,0 +1,271 @@
+import { PNDMScheduler, PNDMSchedulerConfig } from '@/schedulers/PNDMScheduler'
+import { CLIPTokenizer } from '@/tokenizers/CLIPTokenizer'
+import { cat, randomNormalTensor } from '@/util/Tensor'
+import { Tensor } from '@xenova/transformers'
+import { dispatchProgress, loadModel, PretrainedOptions, ProgressCallback, ProgressStatus } from './common'
+import { getModelJSON } from '@/hub'
+import { Session } from '@/backends'
+import { GetModelFileOptions } from '@/hub/common'
+import { PipelineBase } from '@/pipelines/PipelineBase'
+
+export interface StableDiffusionInput {
+  prompt: string
+  negativePrompt?: string
+  guidanceScale?: number
+  seed?: string
+  width?: number
+  height?: number
+  numInferenceSteps: number
+  sdV1?: boolean
+  progressCallback?: ProgressCallback
+  runVaeOnEachStep?: boolean
+  img2imgFlag?: boolean
+  inputImage?: Float32Array
+  strength?: number
+  controlNetImage?: Float32Array
+}
+
+export class StableDiffusionControlNetPipeline extends PipelineBase {
+  declare scheduler: PNDMScheduler
+  declare controlnet: Session
+
+  constructor (unet: Session, controlnet: Session, vaeDecoder: Session, vaeEncoder: Session, textEncoder: Session, tokenizer: CLIPTokenizer, scheduler: PNDMScheduler) {
+    super()
+    this.unet = unet
+    this.controlnet = controlnet
+    this.vaeDecoder = vaeDecoder
+    this.vaeEncoder = vaeEncoder
+    this.textEncoder = textEncoder
+    this.tokenizer = tokenizer
+    this.scheduler = scheduler
+    this.vaeScaleFactor = 8
+  }
+
+  static createScheduler (config: PNDMSchedulerConfig) {
+    return new PNDMScheduler(
+      {
+        prediction_type: 'epsilon',
+        ...config,
+      },
+    )
+  }
+
+  static async fromPretrained (modelRepoOrPath: string, options?: PretrainedOptions) {
+    const opts: GetModelFileOptions = {
+      ...options,
+    }
+
+    // order matters because WASM memory cannot be decreased. so we load the biggest one first
+    const unet = await loadModel(
+      modelRepoOrPath,
+      'unet/model.onnx',
+      opts,
+    )
+    const controlnet = await loadModel(modelRepoOrPath, 'controlnet/model.onnx', opts)
+    const textEncoder = await loadModel(modelRepoOrPath, 'text_encoder/model.onnx', opts)
+    const vaeEncoder = await loadModel(modelRepoOrPath, 'vae_encoder/model.onnx', opts)
+    const vae = await loadModel(modelRepoOrPath, 'vae_decoder/model.onnx', opts)
+
+    const schedulerConfig = await getModelJSON(modelRepoOrPath, 'scheduler/scheduler_config.json', true, opts)
+    const scheduler = StableDiffusionControlNetPipeline.createScheduler(schedulerConfig)
+
+    const tokenizer = await CLIPTokenizer.from_pretrained(modelRepoOrPath, { ...opts, subdir: 'tokenizer' })
+    await dispatchProgress(opts.progressCallback, {
+      status: ProgressStatus.Ready,
+    })
+    return new StableDiffusionControlNetPipeline(unet, controlnet, vae, vaeEncoder, textEncoder, tokenizer, scheduler)
+  }
+
+  async run (input: StableDiffusionInput) {
+    const width = input.width || 512
+    const height = input.height || 512
+    const batchSize = 1
+    const guidanceScale = input.guidanceScale || 7.5
+    const seed = input.seed || ''
+    this.scheduler.setTimesteps(input.numInferenceSteps || 5)
+
+    await dispatchProgress(input.progressCallback, {
+      status: ProgressStatus.EncodingPrompt,
+    })
+
+    const promptEmbeds = await this.getPromptEmbeds(input.prompt, input.negativePrompt)
+
+    const latentShape = [batchSize, 4, width / 8, height / 8]
+    let latents = randomNormalTensor(latentShape, undefined, undefined, 'float32', seed) // Normal latents used in Text-to-Image
+    let timesteps = this.scheduler.timesteps.data
+
+    if (input.img2imgFlag) {
+      const inputImage = input.inputImage || new Float32Array()
+      const strength = input.strength || 0.8
+
+      await dispatchProgress(input.progressCallback, {
+        status: ProgressStatus.EncodingImg2Img,
+      })
+
+      const imageLatent = await this.encodeImage(inputImage, input.width, input.height) // Encode image to latent space
+
+      // Taken from https://towardsdatascience.com/stable-diffusion-using-hugging-face-variations-of-stable-diffusion-56fd2ab7a265#2d1d
+      const initTimestep = Math.round(input.numInferenceSteps * strength)
+      const timestep = timesteps.toReversed()[initTimestep]
+
+      latents = this.scheduler.addNoise(imageLatent, latents, timestep)
+      // Computing the timestep to start the diffusion loop
+      const tStart = Math.max(input.numInferenceSteps - initTimestep, 0)
+      timesteps = timesteps.slice(tStart)
+    }
+
+    const doClassifierFreeGuidance = guidanceScale > 1
+    let humanStep = 1
+    let cachedImages: Tensor[] | null = null
+
+    let controlnetImage = new Tensor('float32', input.controlNetImage || new Float32Array, [1, 3, 512, 512])
+    controlnetImage = doClassifierFreeGuidance ? cat([controlnetImage, controlnetImage.clone()]) : controlnetImage
+    const conditioningScale = new Tensor(new Float64Array([1.0]))
+
+    for (const step of timesteps) {
+        // for some reason v1.4 takes int64 as timestep input. ideally we should get input dtype from the model
+        // but currently onnxruntime-node does not give out types, only input names
+        const timestep = input.sdV1
+            ? new Tensor(BigInt64Array.from([BigInt(step)]))
+            : new Tensor(new Float32Array([step]))
+        await dispatchProgress(input.progressCallback, {
+            status: ProgressStatus.RunningUnet,
+            unetTimestep: humanStep,
+            unetTotalSteps: timesteps.length,
+        })
+        const latentInput = doClassifierFreeGuidance ? cat([latents, latents.clone()]) : latents
+
+        const blocks = await this.applyControlnet(latentInput, timestep, promptEmbeds, controlnetImage, conditioningScale)
+
+        /**
+         * ControlNet blocks output shape:
+         * 24549 -> [2, 320, 64, 64]
+         * 24551 -> [2, 320, 32, 32]
+         * 24553 -> [2, 640, 32, 32]
+         * 24555 -> [2, 640, 32, 32]
+         * 24557 -> [2, 640, 16, 16]
+         * 24559 -> [2, 1280, 16, 16]
+         * 24561 -> [2, 1280, 16, 16]
+         * 24563 -> [2, 1280, 8, 8]
+         * 24565 -> [2, 1280, 8, 8]
+         * 24567 -> [2, 1280, 8, 8]
+         * 24569 -> [2, 1280, 8, 8]
+         * down_block_res_samples -> [2, 320, 64, 64]
+         * mid_block_res_sample -> [2, 320, 64, 64]
+         */
+
+        /**
+         * UNET down_blocks expected input shape:
+         * down_block_0 -> [2, 320, 64, 64]
+         * down_block_1 -> [2, 320, 64, 64]
+         * down_block_2 -> [2, 320, 64, 64]
+         * down_block_3 -> [2, 320, 32, 32]
+         * down_block_4 -> [2, 640, 32, 32]
+         * down_block_5 -> [2, 640, 32, 32]
+         * down_block_6 -> [2, 640, 16, 16]
+         * down_block_7 -> [2, 1280, 16, 16]
+         * down_block_8 -> [2, 1280, 16, 16]
+         * down_block_9 -> [2, 1280, 8, 8]
+         * down_block_10 -> [2, 1280, 8, 8]
+         * down_block_11 -> [2, 1280, 8, 8]
+         * mid_block_additional_residual -> [2, 1280, 8, 8]
+         */
+
+        const noise = await this.unet.run(
+          {
+            sample: latentInput, 
+            timestep, 
+            encoder_hidden_states: promptEmbeds, 
+            down_block_0: blocks.down_block_res_samples,
+            down_block_1: blocks.mid_block_res_sample,
+            down_block_2: blocks["24549"],
+            down_block_3: blocks["24551"],
+            down_block_4: blocks["24553"],
+            down_block_5: blocks["24555"],
+            down_block_6: blocks["24557"],
+            down_block_7: blocks["24559"],
+            down_block_8: blocks["24561"],
+            down_block_9: blocks["24563"],
+            down_block_10: blocks["24565"],
+            down_block_11: blocks["24567"],
+            mid_block_additional_residual: blocks["24569"]
+          },
+        )
+
+        let noisePred = noise.out_sample
+        if (doClassifierFreeGuidance) {
+            const [noisePredUncond, noisePredText] = [
+            noisePred.slice([0, 1]),
+            noisePred.slice([1, 2]),
+            ]
+            noisePred = noisePredUncond.add(noisePredText.sub(noisePredUncond).mul(guidanceScale))
+        }
+
+        latents = this.scheduler.step(
+            noisePred,
+            step,
+            latents,
+        )
+
+        if (input.runVaeOnEachStep) {
+            await dispatchProgress(input.progressCallback, {
+                status: ProgressStatus.RunningVae,
+                unetTimestep: humanStep,
+                unetTotalSteps: timesteps.length,
+            })
+            cachedImages = await this.makeImages(latents)
+        }
+        humanStep++
+        }
+
+        await dispatchProgress(input.progressCallback, {
+            status: ProgressStatus.Done,
+        })
+
+        if (input.runVaeOnEachStep) {
+            return cachedImages!
+        }
+
+        return this.makeImages(latents)
+  }
+
+  async encodeImage (inputImage: Float32Array, width: number, height: number) {
+    const encoded = await this.vaeEncoder.run(
+      { sample: new Tensor('float32', inputImage, [1, 3, width, height]) },
+    )
+
+    const encodedImage = encoded.latent_sample
+    return encodedImage.mul(0.18215)
+  }
+
+  /**
+   * Applies the ControlNet model and returns the down_block_res_samples and mid_block_res_sample
+   * which are used as input for the UNET model as shown in 
+   * https://github.com/huggingface/diffusers/blob/29f15673ed5c14e4843d7c837890910207f72129/src/diffusers/pipelines/controlnet/pipeline_controlnet.py#L943.
+   * Shapes were taken from https://docs.openvino.ai/2023.1/notebooks/235-controlnet-stable-diffusion-with-output.html#controlnet-conversion.
+   * 
+   * @param latentInput Latent Input that is also passed to the UNET. Expected shape: [2, 4, 64, 64]
+   * @param timestep Current timestep. Expected shape: [1]
+   * @param promptEmbeds Text Embeddings consisting of the prompt and negative prompt. Expected shape: [2, 77, 768]
+   * @param controlnet_image Preprocessed ControlNet image. Expected shape: [2, 3, 512, 512]
+   * @param conditioning_scale ControlNet Conditioning Scale. Expected shape: [1]
+   */
+  async applyControlnet(latentInput: Tensor, timestep: Tensor, promptEmbeds: Tensor, controlnet_image: Tensor, conditioning_scale: Tensor) {
+    const blocks = await this.controlnet.run(
+      {
+        "sample": latentInput,
+        "timestep": timestep,
+        "encoder_hidden_states": promptEmbeds,
+        "controlnet_cond": controlnet_image,
+        "conditioning_scale": conditioning_scale
+      }
+    );
+
+    return blocks;
+  }
+
+  async release () {
+    await super.release()
+    return this.controlnet?.release()
+  }
+}


### PR DESCRIPTION
## Description

The changes include adding the `StableDiffusionControlNet` pipeline, specifically the Canny Edge Detection model along with the pre-processing function required to get the ControlNet input image which is done using OpenCV.js. The ControlNet pipeline is similar to the Image-To-Image pipeline since they both require an image as input. The main difference between them is that the Image-To-Image pipeline takes the input image with added noise and uses it as the input latent instead of random noise and the ControlNet pipeline takes the input image and other arguments as input to the ControlNet model which returns outputs (down block samples and middle block sample) that are used as input to the UNET model. The shape of the ControlNet inputs were taken from [here](https://docs.openvino.ai/2023.1/notebooks/235-controlnet-stable-diffusion-with-output.html#controlnet-conversion) and the shape of the UNET inputs were inferred based on the shapes and not the names.

In addition, the Image-To-Image feature was added to the `StableDiffusionControlNet` pipeline which resulted in the creation of the `StableDiffusionControlNetImg2Img` pipeline.

## Convert Command

The command that I used to convert the model was: `python conv_sd_to_onnx.py --model_path "runwayml/stable-diffusion-v1-5" --output_path "./model/sd1-5_fp16_cn_canny" --controlnet_path "lllyasviel/control_v11p_sd15_canny" --fp16 --attention-slicing auto` from the [converter](https://github.com/Amblyopius/Stable-Diffusion-ONNX-FP16#support-for-controlnet) that you use.

## Specific Changes

- [X] Add `src/pipelines/StableDiffusionControlNetPipeline.ts` file.
- [X] Modify `getRgbData()` and `uploadImage()` functions in `examples/react/src/App.tsx` to account for ControlNet image upload.
- [X] Add the `@techstark/opencv-js` and `react-app-rewired` packages to the `examples/react/package.json` file and replace some `react-scripts` with `react-app-rewired` in order to use the OpenCV.js functions.
- [X] Add `examples/react/config-overrides.js` file which is necessary to use OpenCV.js. Taken from [here](https://github.com/TechStark/opencv-js-examples/blob/develop/opencv-js-react-example/config-overrides.js).
 
## Pre-Processing Libraries
 
In this section I'll include all of the pre-processing libraries that I found in case you want to use another one or add other ControlNet model:
- Canny
    - [@techstark/opencv-js](https://www.npmjs.com/package/@techstark/opencv-js/v/4.8.0-release.10): [Example 1](https://docs.opencv.org/4.8.0/d7/de1/tutorial_js_canny.html) | [Example 2](https://codepen.io/wallat/pen/yLymMey) | [Example 3](https://codesandbox.io/s/techstarkopencv-js-demo-page-f7gvk?file=/src/TestPage.jsx)
    - [js-canny-edge-detector](https://github.com/petarjs/js-canny-edge-detector)
    - [CannyJS](https://github.com/yuta1984/CannyJS)
    - [opencv.js](https://www.npmjs.com/package/opencv.js)
- OpenPose
    - [OpenCV.js](https://docs.opencv.org/4.8.0/d1/d0d/tutorial_js_pose_estimation.html)
- Semantic Segmentation
    - [OpenCV.js](https://docs.opencv.org/3.4/dc/d20/tutorial_js_semantic_segmentation.html)
    - [TensorFlow.js](https://selvamsubbiah.com/semantic-image-segmentation-in-browser-using-deeplab/)
 
## Issues / Future Work

- The order of the inputs to the UNET model was inferred based on the input shapes and not the name of the keys. I believe the order of the inputs is correct but I’m not 100% sure.
- For every ControlNet model there is an individual pre-processing function that is needed to get the ControlNet input image. For now, OpenCV.js has the pre-processing functions of Canny, Pose Estimation and Semantic Segmentation. I selected this library because it had the most pre-processing functions that I could find but another library or libraries can be considered in order to add the remaining ControlNet models. Based on my understanding, the Annotators are models that can serve as a replacement for the pre-processing functions. The problem is that I have not found a converter script that can be used to convert these models to ONNX format. I’ll look more into this.
- I was able to convert and use ControlNet 1.0 and 1.1 with SD 1.5. I tried to convert Stable Diffusion 2.1 with [ControlNet for SD 2.1](https://huggingface.co/thibaud) but was not successful. I'll look more into this as well.
- For now, I have the Canny ControlNet model hosted in my HuggingFace repo but I can transfer this model to you if you want to.