### PR TITLE
Infinite Prompt Length Feature

### DIFF
--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -46,7 +46,7 @@ interface SelectedPipeline {
 const pipelines = [
   {
     name: 'LCM Dreamshaper FP16 (2.2GB)',
-    repo: 'aislamov/lcm-dreamshaper-fp16',
+    repo: 'aislamov/lcm-dreamshaper-v7-onnx',
     revision: 'main',
     fp16: true,
     width: 512,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "wasm-feature-detect": "^1.5.1"
   },
   "scripts": {
+    "prepare": "npm run build",
     "build": "npm run build:ts && npm run build:types",
     "build:ts": "node scripts/build.js",
     "build:types": "tsc --emitDeclarationOnly",

--- a/src/pipelines/LatentConsistencyModelPipeline.ts
+++ b/src/pipelines/LatentConsistencyModelPipeline.ts
@@ -98,7 +98,19 @@ export class LatentConsistencyModelPipeline extends PipelineBase {
       status: ProgressStatus.EncodingPrompt,
     })
 
-    const promptEmbeds = await this.encodePrompt(input.prompt)
+    const tokens = this.tokenizer(
+      input.prompt,
+      {
+        return_tensor: false,
+        padding: false,
+        max_length: this.tokenizer.model_max_length,
+        return_tensor_dtype: 'int32',
+      },
+    )
+
+    // Get the maximum length between the prompt and the tokenizer model max length
+    const highestTokenLength = Math.max(tokens.input_ids.length, this.tokenizer.model_max_length)
+    const promptEmbeds = await this.encodePrompt(input.prompt, highestTokenLength)
 
     let latents = this.prepareLatents(
       batchSize,

--- a/src/pipelines/PipelineBase.ts
+++ b/src/pipelines/PipelineBase.ts
@@ -13,26 +13,107 @@ export class PipelineBase {
   public scheduler: SchedulerBase
   public vaeScaleFactor: number
 
-  async encodePrompt (prompt: string): Promise<Tensor> {
-    const tokens = this.tokenizer(
+  /**
+   * Tokenizes and encodes the input prompt. Before encoding, we verify if it is necessary
+   * to break the prompt into chunks due to the Tokenizer model limit (which is usually 77)
+   * by getting the maximum length of the input prompt and comparing it with the Tokenizer
+   * model max length. If the prompt exceeds the Tokenizer model limit, then it is
+   * necessary to break the prompt into chunks, otherwise, it is not necessary.
+   * 
+   * @param prompt Input prompt.
+   * @param highestTokenLength Highest token length between prompt and negative prompt or Tokenizer model max length.
+   * @returns Tensor containing the prompt embeddings.
+   */
+  async encodePrompt (prompt: string, highestTokenLength: number): Promise<Tensor> {
+    let tokens, encoded, inputIds;
+    const TokenMaxLength = this.tokenizer.model_max_length // Tokenizer model max length of tokens including the <START> and <END> tokens
+
+    if(highestTokenLength > TokenMaxLength) { // Prompt exceeds tokenizer model max length, therefore we need to use chunks
+      let embeddingsTensorArray: Tensor[] = [] // Will contain all of the prompt token embedding chunks
+      const userTokenMaxLength = TokenMaxLength - 2 // Max length of tokens minus the <START> and <END> tokens
+
+      tokens = this.tokenizer(
+        prompt,
+        {
+          return_tensor: false,
+          padding: false,
+          max_length: TokenMaxLength,
+          return_tensor_dtype: 'int32',
+        },
+      )
+
+      inputIds = tokens.input_ids // Tokenized prompt
+      const START_token = inputIds.shift() // Remove <START> token
+      const END_token = inputIds.pop() // Remove <END> token
+
+      for(let i = 0; i < highestTokenLength; i += userTokenMaxLength) {
+        let tokenChunk = inputIds.slice(i, i + userTokenMaxLength)
+        
+        for(let j = tokenChunk.length; j < userTokenMaxLength; j++) { // Pad chunk to userTokenMaxLength if necessary. Use the <END> token to pad.
+          tokenChunk.push(END_token)
+        }
+
+        tokenChunk.unshift(START_token) // Add <START> token to each chunk
+        tokenChunk.push(END_token) // Add <END> token to each chunk
+
+        encoded = await this.textEncoder.run({ input_ids: new Tensor('int32', Int32Array.from(tokenChunk.flat()), [1, tokenChunk.length]) })
+        embeddingsTensorArray.push(encoded.last_hidden_state)
+      }
+
+      return cat(embeddingsTensorArray, 1)
+    }
+    else { // Prompt that does not exceed tokenizer max length. Padding is used.
+      tokens = this.tokenizer(
+        prompt,
+        {
+          return_tensor: false,
+          padding: true,
+          max_length: TokenMaxLength,
+          return_tensor_dtype: 'int32',
+        },
+      )
+
+      inputIds = tokens.input_ids // Tokenized prompt
+      encoded = await this.textEncoder.run({ input_ids: new Tensor('int32', Int32Array.from(inputIds.flat()), [1, inputIds.length]) })
+      return encoded.last_hidden_state
+    }
+  }
+
+  /**
+   * Returns the prompt and negative prompt text embeddings.
+   * 
+   * @param prompt Input prompt.
+   * @param negativePrompt Input negative prompt.
+   * @returns Tensor containing the prompt and negative prompt embeddings.
+   */
+  async getPromptEmbeds (prompt: string, negativePrompt: string | undefined) {
+    // We check which has more tokens between the prompt and negative prompt
+    const promptTokens = this.tokenizer(
       prompt,
       {
         return_tensor: false,
-        padding: true,
+        padding: false,
         max_length: this.tokenizer.model_max_length,
         return_tensor_dtype: 'int32',
       },
     )
 
-    const inputIds = tokens.input_ids
-    // @ts-ignore
-    const encoded = await this.textEncoder.run({ input_ids: new Tensor('int32', Int32Array.from(inputIds.flat()), [1, inputIds.length]) })
-    return encoded.last_hidden_state
-  }
+    const negPromptTokens = this.tokenizer(
+      negativePrompt,
+      {
+        return_tensor: false,
+        padding: false,
+        max_length: this.tokenizer.model_max_length,
+        return_tensor_dtype: 'int32',
+      },
+    )
 
-  async getPromptEmbeds (prompt: string, negativePrompt: string | undefined) {
-    const promptEmbeds = await this.encodePrompt(prompt)
-    const negativePromptEmbeds = await this.encodePrompt(negativePrompt || '')
+    const promptTokensLength = promptTokens.input_ids.length // Number of tokens in prompt including the <START> and <END> tokens
+    const negPromptTokensLength = negPromptTokens.input_ids.length // Number of tokens in negative prompt including the <START> and <END> tokens
+    const highestTokenLength = Math.max(promptTokensLength, negPromptTokensLength)
+
+    const promptEmbeds = await this.encodePrompt(prompt, highestTokenLength)
+    const negativePromptEmbeds = await this.encodePrompt(negativePrompt || '', highestTokenLength)
 
     return cat([negativePromptEmbeds, promptEmbeds])
   }


### PR DESCRIPTION
## Problem

Currently, there is a limit to the number of tokens that can be passed to the CLIP Text Encoder (usually 77 tokens) as explained [here](https://github.com/huggingface/diffusers/issues/2136). If an input prompt should contain more than the maximum token length, the following error will be shown:

![image](https://github.com/dakenf/diffusers.js/assets/68886123/85b105cd-426f-48c5-828b-892cddc524c7)
 
 ## Solution
 
 In order to overcome this limit and take longer prompts, AUTOMATIC1111 has [this solution](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Features#infinite-prompt-length) which consists of breaking the prompt tokens into chunks, encoding each chunk, and concatenating the encoded chunks in a Tensor before passing it to the UNET model. [Here](https://blog.novelai.net/novelai-improvements-on-stable-diffusion-e10d38db82ac#8871) is another useful explanation of the solution.
 
 One important detail is that in order to achieve this, I had to make sure the token lengths of the prompt and negative prompt were the same, otherwise, there would be an error when concatenating the Tensors. There is no need to break the prompt in chunks if the tokens length doesn't exceed the Tokenizer model max length.
 
## Long Prompt Results

Before this change, the following long prompts would fail, but now they produce the following images (generated with the LCM Pipeline):

- inspired by realflow-cinema4d editor features, create image of a transparent luxury cup with ice fruits and mint, connected with white, yellow and pink cream, Slow - High Speed MO Photography, 4K Commercial Food, YouTube Video Screenshot, Abstract Clay, Transparent Cup , molecular gastronomy, wheel, 3D fluid,Simulation rendering, still video, 4k polymer clay futras photography, very surreal, Houdini Fluid Simulation, hyperrealistic CGI and FLUIDS & MULTIPHYSICS SIMULATION effect, with Somali Stain Lurex, Metallic Jacquard, Gold Thread, Mulberry Silk, Toub Saree, Warm background, a fantastic image worthy of an award.

![inspired](https://github.com/dakenf/diffusers.js/assets/68886123/922e0a1b-77f5-4ce6-abf7-abf9906d2393)

- fantasy medieval village world inside a glass sphere , high detail, fantasy, realistic, light effect, hyper detail, volumetric lighting, cinematic, macro, depth of field, blur, red light and clouds from the back, highly detailed epic cinematic concept art cg render made in maya, blender and photoshop, octane render, excellent composition, dynamic dramatic cinematic lighting, aesthetic, very inspirational, world inside a glass sphere by james gurney by artgerm with james jean, joe fenton and tristan eaton by ross tran, <lora:epinoiseoffset_v2:0.35>, fine details, 4k resolution, <lora:add_detail:0.25>

![fantasy](https://github.com/dakenf/diffusers.js/assets/68886123/3d196889-5775-46e8-a901-34dbb191b055)

## Other

- Fixed a typo in the repo name of the LCM Dreamshaper FP16 model.
- I noticed that the negative prompt is not used in the LCM Pipeline. Not sure if this is the intended usage, but wanted to mention it just in case.