### PR TITLE
Comment out line not yet ready for production

### DIFF
--- a/src/tokenizers/CLIPTokenizer.ts
+++ b/src/tokenizers/CLIPTokenizer.ts
@@ -204,7 +204,7 @@ export class CLIPTokenizer extends PreTrainedTokenizer {
     }
 
     // Optional post-processing
-    modelInputs = this.prepare_model_inputs(modelInputs)
+    // modelInputs = this.prepare_model_inputs(modelInputs)
 
     return modelInputs
   }


### PR DESCRIPTION
This patch fixes the following error: `this.prepare_model_inputs is not a function`